### PR TITLE
Fixed a null reference bug

### DIFF
--- a/lib/reviewer.js
+++ b/lib/reviewer.js
@@ -160,7 +160,7 @@ class Reviewer {
       this.log.debug(`Previous comments: ${previousComments.length}`);
 
       const shaComments = previousComments
-        .filter(({ state: { sha } }) => sha === pr.sha);
+        .filter(c => c.state && c.state.sha && c.state.sha === pr.sha);
 
       // TODO: pick most recent or is last enough?
       const previousComment = [...shaComments].pop();

--- a/lib/reviewer.test.js
+++ b/lib/reviewer.test.js
@@ -324,3 +324,25 @@ test('Reviewer.review - pr state', async t => {
 
   t.false(t.context.github.createStatus.called);
 });
+
+test('Reviewer.review - bad comment state', async t => {
+  t.context.github.getIssueComments = sinon.stub().returns(Promise.resolve([
+    { user: { login: SelfLogin }, body: 'trigger now' },
+  ]));
+
+  const config = createTestConfig({
+    review: {
+      test_provider: false,
+    },
+  });
+
+  const r = new Reviewer({
+    config,
+    github: t.context.github,
+    log: createTestLog(),
+  });
+
+  await r.review(t.context.pr);
+
+  t.true(t.context.github.getIssueComments.called);
+});


### PR DESCRIPTION
I am not 100% sure of the root cause of this issue but this is something that we see everyday. Maybe it is caused from our version of Github? But either way, we commonly see that the `state` object is null, which leads to a exception. 

For reference, here is an example of the exception. I have had this patched for a few months now, but want to give back incase others are having the same issue.

```
2017-10-02T15:17:10.712364042Z TypeError: Cannot match against 'undefined' or 'null'.
2017-10-02T15:17:10.712376482Z     at /usr/src/app/lib/reviewer.js:163:17
2017-10-02T15:17:10.712379908Z     at Array.filter (native)
2017-10-02T15:17:10.71238277Z     at Reviewer.<anonymous> (/usr/src/app/lib/reviewer.js:163:10)
2017-10-02T15:17:10.712386245Z     at Generator.next (<anonymous>)
2017-10-02T15:17:10.71238936Z     at step (/usr/src/app/lib/reviewer.js:28:191)
2017-10-02T15:17:10.71239204Z     at /usr/src/app/lib/reviewer.js:28:361
2017-10-02T15:17:10.712394732Z     at process._tickDomainCallback (internal/process/next_tick.js:135:7)
```