### PR TITLE
Link should be lowercase

### DIFF
--- a/lib/minihub.js
+++ b/lib/minihub.js
@@ -39,7 +39,7 @@ class MiniHub {
   async handleLinkHeader(requestOptions, response) {
     // TODO: do link processing not recursively?
     if (Array.isArray(response.data)) {
-      const linkHeader = response.headers.Link;
+      const linkHeader = response.headers.link;
 
       if (linkHeader) {
         const links = {};

--- a/lib/minihub.test.js
+++ b/lib/minihub.test.js
@@ -13,7 +13,7 @@ test('Link header parsing', async t => {
   mh.axios = {
     request: async () => ({
       headers: {
-        Link: '<https://example.com?page=1>; rel="previous"',
+        link: '<https://example.com?page=1>; rel="previous"',
       },
       data: [3, 4],
     }),
@@ -21,7 +21,7 @@ test('Link header parsing', async t => {
 
   const { data } = await mh.handleLinkHeader({ url: 'https://example.com/?page=1' }, {
     headers: {
-      Link: '<https://example.com?page=2>; rel="next"',
+      link: '<https://example.com?page=2>; rel="next"',
     },
     data: [1, 2],
   });


### PR DESCRIPTION
This one is hard to prove but we ran into issues with a long review on a PR. The link logic didn't pick up the next page because the res header was a lowercase `link`. I can't find direct documentation of this but I was able to replicate it with a PR after adding a bunch of junk comments.

I tested with the new API - https://developer.github.com/v3/pulls/reviews/