### PR TITLE
CHORE: Change GH url to match new home

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -36,7 +36,7 @@ const defaultConfig = {
     do_not_merge: true,
   },
   comment: {
-    footer: '\n\n---\nTo sign-off on a PR once you are mentioned, leave a comment with `LGTM`, `:+1:` or `:ship_it:`.\n\n*This comment was left by the [Further Review](https://github.com/paultyng/further-review) PR review app.*',
+    footer: '\n\n---\nTo sign-off on a PR once you are mentioned, leave a comment with `LGTM`, `:+1:` or `:ship_it:`.\n\n*This comment was left by the [Further Review](https://github.com/underarmour/further-review) PR review app.*',
   },
 };
 


### PR DESCRIPTION
The FR comment footer links to the `ptyng` repo still, this PR corrects that.