### PR TITLE
Add ability to whitelist users to bypass provider checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,37 @@ Further Review works best when the `master` branch is protected until it reviews
 
 To just subscribe to files for notification but not be required for review, you can add a targeted review with zero required sign-offs.
 
+## Whitelisted Users / Tools
+
+When using a tool that creates automatically managed PRs, such as Greenkeeper or Renovate, you may wish to bypass FR.
+
+Use the `users_whitelist` config setting to provide a list of users.  If a PR is opened for a user in that list, the status check
+will be marked as successful and the providers will not run against it.
+
+```yaml
+users_whitelist:
+  - greenkeeper
+  - renovate
+reviews:
+  - name: Package.json Maintainers
+    # List of GitHub usernames
+    logins:
+      # All three of the following formats are supported:
+      - paultyng
+      - paultyng <paul@example.com>
+      - Paul Tyng <paul@example.com> (@paultyng)
+    # Optional glob to match on
+    glob: package.json
+    # Number of required sign offs
+    required: 1
+  # Multiple reviews can be listed.
+  - name: General Maintainers
+    logins:
+      - user1
+      - user2
+
+```
+
 ## Inspirations
 
 * [LGTM](https://lgtm.co)

--- a/lib/reviewer.js
+++ b/lib/reviewer.js
@@ -101,12 +101,17 @@ class Reviewer {
   }
 
   renderComment(results, state) {
-    const stateMd = this.renderCommentState(state);
+    const { isOwnerWhitelisted, owner, ...remain } = state;
+    const stateMd = this.renderCommentState(remain);
+
+    const body = isOwnerWhitelisted ?
+          `@${owner} is whitelisted, no review required.` :
+          results.map(({ comment }) => comment).join('');
 
     return dedent`${stateMd}
       ## Further Review Needed
 
-      ${results.map(({ comment }) => comment).join('')}
+      ${body}
 
       ${this.config('comment:footer') || ''}
     `;
@@ -165,9 +170,12 @@ class Reviewer {
       // TODO: pick most recent or is last enough?
       const previousComment = [...shaComments].pop();
 
-      const providers = await this.prepareProviders();
+      const whitelist = this.config('users_whitelist');
+      const isOwnerWhitelisted = whitelist && whitelist.includes(pr.owner);
 
-      if (providers.length === 0) {
+      const providers = isOwnerWhitelisted ? [] : await this.prepareProviders();
+
+      if (!isOwnerWhitelisted && providers.length === 0) {
         this.log.warn('No providers run.');
         return pr;
       }
@@ -190,6 +198,8 @@ class Reviewer {
       const newState = {
         sha: pr.sha,
         providers: instances.map(({ name }) => name),
+        owner: pr.owner,
+        isOwnerWhitelisted,
       };
 
       const newBody = this.renderComment(results, newState).trim();

--- a/lib/reviewer.test.js
+++ b/lib/reviewer.test.js
@@ -189,6 +189,40 @@ test('Reviewer.review - simple success', async t => {
   );
 });
 
+test('Reviewer.review - whitelisted user', async t => {
+  class TestProvider extends BaseProvider {
+    async review() {
+      return {
+        success: false,
+        comment: 'Test failure comment',
+      };
+    }
+  }
+
+  const providers = { test_provider: TestProvider };
+  const config = createTestConfig({
+    users_whitelist: ['paultyng'],
+    review: {
+      test_provider: true,
+    },
+  });
+
+  const r = new Reviewer({
+    config,
+    github: t.context.github,
+    providers,
+    log: createTestLog(),
+  });
+
+  await r.review(t.context.pr);
+
+  t.true(t.context.github.createStatus.calledTwice);
+  t.deepEqual(
+    t.context.github.createStatus.args.map(([{ state }]) => state),
+    ['pending', 'success']
+  );
+});
+
 test('SignOffProvider.review - already commented', async t => {
   class TestProvider extends BaseProvider {
     async review() {
@@ -206,7 +240,6 @@ test('SignOffProvider.review - already commented', async t => {
   `.trim();
 
   t.context.github.getIssueComments = sinon.stub().returns(Promise.resolve([
-    // eslint-disable-next-line max-len
     { user: { login: SelfLogin }, body: expectedBody },
   ]));
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "further-review",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Pull request process enforcer.",
   "keyword": [
     "pull request",


### PR DESCRIPTION
This was inspired by the desire to have tools make chore PRs without FR being required.  Greenkeeper, Renovate, etc.

Adds a config setting of `whitelistUsers` to the root, and if a PR is opened by a GH user of the same name, the providers will be skipped and the PR status will be set to successful.